### PR TITLE
Added node.js setup information for fish shell and changed path for inst...

### DIFF
--- a/setup/install_node_from_source.md
+++ b/setup/install_node_from_source.md
@@ -12,7 +12,7 @@ This is only if you need to, generally just on Linux systems.
 ```
 tar -xvf <the node tar.gz you downloaded>
 cd <node directory>
-./configure --prefix=~/.node
+./configure --prefix=$HOME/.node
 make && make install
 ```
 
@@ -20,6 +20,12 @@ make && make install
 ```
 export PATH=$PATH:$HOME/.node/bin
 export NODE_PATH=$HOME/.node/lib/node_modules
+```
+
+or for fish, add the following to config.fish (~/.config/fish/config.fish)
+```
+set -gx PATH $PATH $HOME/.node/bin
+set -gx NODE_PATH $HOME/.node/lib/node_modules
 ```
 
 ## Making sure it works


### PR DESCRIPTION
...allation directory

The previous installation directory "./configure --prefix=~/.node" creates new directories ./~/.node within the current directory. Using $HOME/.node or /home/userName/.node fixes this.

Added fish shell instructions for adding PATH to config.fish because the syntax is different.