### PR TITLE
(markup) improve superagent markup

### DIFF
--- a/day8/superagent_testing.md
+++ b/day8/superagent_testing.md
@@ -1,12 +1,12 @@
 Testing with Super Agent
 ===============================
-Super Agent is a tool to make REST requests from within Node. It makesthe sending requests
-as easy as .put or .get, much in the same way that express allows you to simplify the handling
+Super Agent is a tool to make REST requests from within Node. It makes the sending requests
+as easy as `.put` or `.get`, much in the same way that express allows you to simplify the handling
 of incoming REST requests. While Super Agent is not specifically designed to test JSON apis,
 it greatly simplifies acceptance testing of said JSON apis. Testing using Super Agent requires
 both a testing framework, as well as a collection of expect statements. Also being able to run
 tests from Grunt is key. A combination of Mocha and Chai should fit the bill nicely. First run
-`npm install superagent chai mocha --save` then create a test file test/api/notes_api_test.js with the
+`npm install superagent chai mocha --save` then create a test file entitled `test/api/notes_api_test.js` with the
 following code:
 ```javascript
 var superagent = require('superagent');
@@ -70,4 +70,4 @@ describe('Notes JSON api', function() {
   });
 });
 ```
-Some interesting things happen in this code, first when app is required from server.js it actually starts the server before sending JSON requests to it. When each request is sent to the server it returns a callback response that should contain a successful JSON object.  In the case of the creation of this object(the POST request) it returns a copy of the object that presumably has been saved to a persistent database. It's integration testing, so while it's not precise it does test the general use case for the JSON api.```')})})```
+Some interesting things happen in this code, first when app is required from server.js it actually starts the server before sending JSON requests to it. When each request is sent to the server it returns a callback response that should contain a successful JSON object.  In the case of the creation of this object(the POST request) it returns a copy of the object that presumably has been saved to a persistent database. It's integration testing, so while it's not precise it does test the general use case for the JSON api.


### PR DESCRIPTION
* Include space in-between `makesthe`
* Include code spans
* Remove trailing parenthesis and brackets from the end of the section